### PR TITLE
Refactor/exception-handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The database uses a single table `book` to store all book types using a **Single
 | `title` | `VARCHAR(255)` |`NOT NULL`| The title of the book |
 | `author` | `VARCHAR(255)` |`NOT NULL`| The author of the book |
 | `stock` | `INT` |`NOT NULL`, `DEFAULT 0`| The current number of copies in stock. All entries will have a specified stock count, even if it's zero. |
-| `book_type` | `VARCHAR(31)` |`NOT NULL`| The discriminator column that indicates the specific book type (e.g., `Ebook` and `PhysicalCopyBook`) |
+| `book_type` | `VARCHAR(31)` |`NOT NULL`| The discriminator column that indicates the specific book type (e.g., `ebook` and `physical_copy`) |
 
 A database dump file is included in the project to allow for easy restoration of the application's database schema and data.
 

--- a/bookstore-api/src/test/java/com/rafiatolowo/bookstore_api/Book/BookControllerIntegrationTest.java
+++ b/bookstore-api/src/test/java/com/rafiatolowo/bookstore_api/Book/BookControllerIntegrationTest.java
@@ -1,0 +1,237 @@
+package com.rafiatolowo.bookstore_api.book;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Description;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
+import com.rafiatolowo.bookstore_api.BookstoreApiApplication;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Integration tests for the BookController class.
+ */
+
+@SpringBootTest(classes = BookstoreApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class BookControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    private URI baseUri;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockBean
+    private BookService bookService;
+
+    private List<Book> defaultBooks = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        this.baseUri = UriComponentsBuilder.newInstance()
+                .scheme("http")
+                .host("localhost")
+                .port(port)
+                .path("api/books")
+                .build()
+                .toUri();
+
+        // Some sample data for the mock service
+        defaultBooks.add(new EBook("978-0135957059", "The Pragmatic Programmer", "Andrew Hunt, David Thomas", 100));
+        defaultBooks.add(new PhysicalCopyBook("978-0441172719", "Dune", "Frank Herbert", 50));
+        when(bookService.getAllBooks()).thenReturn(defaultBooks);
+    }
+
+    @Test
+    @Description("GET /api/books Test for getting all books")
+    void testGetAllBooks_returnsAllBooks() {
+        // Act
+        ResponseEntity<List<Book>> response = restTemplate.exchange(
+                baseUri,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<Book>>() {});
+        List<Book> responseBooks = response.getBody();
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(responseBooks);
+        assertEquals(defaultBooks.size(), responseBooks.size());
+        verify(bookService).getAllBooks();
+    }
+
+    @Test
+    void testAddBook_returnsCreatedBook() {
+        // Arrange
+        Book newBook = new EBook("978-1234567890", "Test Title", "Test Author", 10);
+        when(bookService.addBook(any(Book.class))).thenReturn(newBook);
+
+        // Act
+        ResponseEntity<Book> response = restTemplate.postForEntity(baseUri, newBook, Book.class);
+
+        // Assert
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(newBook.getIsbn(), response.getBody().getIsbn());
+        verify(bookService).addBook(any(Book.class));
+    }
+
+    @Test
+    void testAddBook_returnsConflictWhenBookAlreadyExists() {
+        // Arrange
+        Book existingBook = new EBook("978-0135957059", "The Pragmatic Programmer", "Andrew Hunt, David Thomas", 100);
+        when(bookService.addBook(any(Book.class))).thenThrow(new IllegalStateException("Book already exists"));
+
+        // Act
+        ResponseEntity<Void> response = restTemplate.postForEntity(baseUri, existingBook, Void.class);
+
+        // Assert
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        verify(bookService).addBook(any(Book.class));
+    }
+
+    @Test
+    void testGetBookByIsbn_returnsBook() {
+        // Arrange
+        String isbn = defaultBooks.get(0).getIsbn();
+        when(bookService.findByIsbn(isbn)).thenReturn(Optional.of(defaultBooks.get(0)));
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment(isbn).build().toUri();
+
+        // Act
+        ResponseEntity<Book> response = restTemplate.getForEntity(endpoint, Book.class);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(isbn, response.getBody().getIsbn());
+        verify(bookService).findByIsbn(isbn);
+    }
+
+    @Test
+    void testGetBookByIsbn_returnsNotFound() {
+        // Arrange
+        String isbn = "non-existent-isbn";
+        when(bookService.findByIsbn(isbn)).thenReturn(Optional.empty());
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment(isbn).build().toUri();
+
+        // Act
+        ResponseEntity<Void> response = restTemplate.getForEntity(endpoint, Void.class);
+
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(bookService).findByIsbn(isbn);
+    }
+
+    @Test
+    void testGetBooksByAuthor_returnsBooks() {
+        // Arrange
+        String author = "Frank Herbert";
+        List<Book> duneBooks = new ArrayList<>();
+        duneBooks.add(defaultBooks.get(1));
+
+        when(bookService.findBooksByAuthor(author)).thenReturn(duneBooks);
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment("author", author).build().toUri();
+
+        // Act
+        ResponseEntity<List<Book>> response = restTemplate.exchange(
+                endpoint,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<Book>>() {});
+        List<Book> responseBooks = response.getBody();
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(responseBooks);
+        assertEquals(1, responseBooks.size());
+        assertEquals(author, responseBooks.get(0).getAuthor());
+        verify(bookService).findBooksByAuthor(author);
+    }
+
+    @Test
+    void testUpdateBook_returnsUpdatedBook() {
+        // Arrange
+        String isbn = defaultBooks.get(0).getIsbn();
+        Book updatedBookData = new PhysicalCopyBook(isbn, "Updated Title", "Updated Author", 50);
+
+        when(bookService.updateBook(eq(isbn), any(Book.class))).thenReturn(updatedBookData);
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment(isbn).build().toUri();
+
+        // Act
+        ResponseEntity<Book> response = restTemplate.exchange(endpoint, HttpMethod.PATCH, new HttpEntity<>(updatedBookData), Book.class);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("Updated Title", response.getBody().getTitle());
+        verify(bookService).updateBook(eq(isbn), any(Book.class));
+    }
+
+    @Test
+    void testUpdateBook_returnsNotFoundForNonExistentBook() {
+        // Arrange
+        String isbn = "non-existent-isbn";
+        Book updatedBookData = new EBook(isbn, "Updated Title", "Updated Author", 50);
+
+        when(bookService.updateBook(eq(isbn), any(Book.class))).thenThrow(new IllegalStateException("Book not found"));
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment(isbn).build().toUri();
+
+        // Act
+        ResponseEntity<Void> response = restTemplate.exchange(endpoint, HttpMethod.PATCH, new HttpEntity<>(updatedBookData), Void.class);
+
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(bookService).updateBook(eq(isbn), any(Book.class));
+    }
+
+    @Test
+    void testDeleteBook_returnsNoContent() {
+        // Arrange
+        String isbn = defaultBooks.get(0).getIsbn();
+        when(bookService.deleteBookByIsbn(isbn)).thenReturn(true);
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment(isbn).build().toUri();
+
+        // Act
+        ResponseEntity<Void> response = restTemplate.exchange(endpoint, HttpMethod.DELETE, null, Void.class);
+
+        // Assert
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(bookService).deleteBookByIsbn(isbn);
+    }
+
+    @Test
+    void testDeleteBook_returnsNotFoundForNonExistentBook() {
+        // Arrange
+        String isbn = "non-existent-isbn";
+        when(bookService.deleteBookByIsbn(isbn)).thenReturn(false);
+        URI endpoint = UriComponentsBuilder.fromUri(baseUri).pathSegment(isbn).build().toUri();
+
+        // Act
+        ResponseEntity<Void> response = restTemplate.exchange(endpoint, HttpMethod.DELETE, null, Void.class);
+
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(bookService).deleteBookByIsbn(isbn);
+    }
+}

--- a/bookstore-api/src/test/java/com/rafiatolowo/bookstore_api/Book/BookControllerUnitTest.java
+++ b/bookstore-api/src/test/java/com/rafiatolowo/bookstore_api/Book/BookControllerUnitTest.java
@@ -1,28 +1,20 @@
 package com.rafiatolowo.bookstore_api.book;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Unit tests for the BookController class using MockMvc.
+ * These tests focus only on the controller's logic, without starting the full application.
+ */
 @WebMvcTest(BookController.class)
 public class BookControllerUnitTest {
 
@@ -31,178 +23,28 @@ public class BookControllerUnitTest {
 
     @MockBean
     private BookService bookService;
-    
-    // ObjectMapper is used to convert Java objects to JSON strings
-    @Autowired
-    private ObjectMapper objectMapper;
 
-    // This test verifies a successful GET request for all book types.
     @Test
-    void testGetAllBooks() throws Exception {
-        // Arrange: Create a fake list of books that the mock service will return.
-        EBook book1 = new EBook("978-0134685991", "Clean Code", "Robert C. Martin", 100);
-        PhysicalCopyBook book2 = new PhysicalCopyBook("978-0134685992", "The Clean Coder", "Robert C. Martin", 80);
-        List<Book> allBooks = Arrays.asList(book1, book2);
+    void testDeleteBookByIsbn_notFound_returnsNotFound() throws Exception {
+        // Arrange
+        String isbn = "978-9999999999";
+        String expectedMessage = "Book not found with ISBN: " + isbn;
+        when(bookService.deleteBookByIsbn(isbn)).thenReturn(false);
 
-        // Tell the mock service what to return when its getAllBooks method is called
-        when(bookService.getAllBooks()).thenReturn(allBooks);
-
-        // Act: Perform a GET request to the controller.
-        mockMvc.perform(get("/api/books"))
-               .andExpect(status().isOk())
-               // Assert: Verify the content of the JSON array.
-                // The order might not be guaranteed, so it's safer to check for existence and properties.
-                .andExpect(jsonPath("$[0].title").value("Clean Code"))
-                .andExpect(jsonPath("$[0].bookType").value("ebook")) // Verify the type of the first book.
-                .andExpect(jsonPath("$[1].title").value("The Clean Coder"))
-                .andExpect(jsonPath("$[1].bookType").value("physical_copy")); // Verify the type of the second book.
-    }
-
-   
-    // This test verifies a successful POST request to add an Ebook.
-    @Test
-    void testAddEBookSuccess() throws Exception {
-        // Arrange: Create a sample EBook to add.
-        EBook newEbook = new EBook("978-1234567890", "Test Driven Development", "Kent Beck", 50);
-        
-        // Mock the service to return the EBook when addBook is called.
-        when(bookService.addBook(any(Book.class))).thenReturn(newEbook);
-
-        // Act & Assert: Perform a POST request and verify the response.
-        mockMvc.perform(post("/api/books")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(newEbook)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.title").value("Test Driven Development"))
-                .andExpect(jsonPath("$.bookType").value("ebook"));
-    }
-
-    // This test verifies a successful POST request for a PhysicalCopyBook.
-    @Test
-    void testAddPhysicalCopyBookSuccess() throws Exception {
-        // Arrange: Create a sample PhysicalCopyBook to add.
-        PhysicalCopyBook newPhysicalBook = new PhysicalCopyBook("978-0201485677", "The Mythical Man-Month", "Frederick Brooks Jr.", 75);
-        
-        // Mock the service to return the PhysicalCopyBook when addBook is called.
-        when(bookService.addBook(any(Book.class))).thenReturn(newPhysicalBook);
-
-        // Act & Assert: Perform a POST request and verify the response.
-        mockMvc.perform(post("/api/books")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(newPhysicalBook)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.title").value("The Mythical Man-Month"))
-                .andExpect(jsonPath("$.bookType").value("physical_copy"));
-    }
-
-    // This test verifies that the API returns a conflict status when a duplicate book is added.
-    @Test
-    void testAddBookConflict() throws Exception {
-        // Arrange: Create a book that already exists
-        EBook existingBook = new EBook("978-1234567890", "Duplicate Book", "Jane Doe", 20);
-
-        // Tell the mock service to throw an exception when addBook is called with a duplicate ISBN
-        when(bookService.addBook(any(Book.class))).thenThrow(new IllegalStateException("A book with this ISBN already exists."));
-
-        // Act & Assert: Perform a POST request and verify a CONFLICT status is returned
-        mockMvc.perform(post("/api/books")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(existingBook)))
-                .andExpect(status().isConflict());
-    }
-    
-    @Test
-    void testGetBookByIsbnSuccess() throws Exception {
-        // Arrange: Create a book that the service will return
-        EBook foundBook = new EBook("978-0134685991", "Clean Code", "Robert C. Martin", 100);
-
-        // Tell the mock service to return the book when findByIsbn is called
-        when(bookService.findByIsbn("978-0134685991")).thenReturn(Optional.of(foundBook));
-        
-        // Act & Assert: Perform a GET request and verify the response
-        mockMvc.perform(get("/api/books/{isbn}", "978-0134685991"))
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$.title").value("Clean Code"));
-    }
-    
-    @Test
-    void testGetBookByIsbnNotFound() throws Exception {
-        // Arrange: Tell the mock service to return an empty Optional
-        when(bookService.findByIsbn("978-1234567890")).thenReturn(Optional.empty());
-        
-        // Act & Assert: Perform a GET request and verify a NOT_FOUND status
-        mockMvc.perform(get("/api/books/{isbn}", "978-1234567890"))
-               .andExpect(status().isNotFound());
+        // Act & Assert
+        mockMvc.perform(delete("/api/books/{isbn}", isbn))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(expectedMessage));
     }
 
     @Test
-    void testGetBooksByAuthor() throws Exception {
-        // Arrange: Create a fake list of books for a specific author using the concrete class
-        EBook book1 = new EBook("978-0134685991", "Clean Code", "Robert C. Martin", 100);
-        EBook book2 = new EBook("978-0134685992", "The Clean Coder", "Robert C. Martin", 80);
-        List<Book> books = Arrays.asList(book1, book2);
+    void testDeleteBookByIsbn_success_returnsNoContent() throws Exception {
+        // Arrange
+        String isbn = "978-0321765723";
+        when(bookService.deleteBookByIsbn(isbn)).thenReturn(true);
 
-        // Tell the mock service what to return when its findBooksByAuthor method is called
-        when(bookService.findBooksByAuthor("Robert C. Martin")).thenReturn(books);
-
-        // Act & Assert: Perform a GET request to the endpoint and verify the response
-        mockMvc.perform(get("/api/books/author/{author}", "Robert C. Martin"))
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$[0].author").value("Robert C. Martin"))
-               .andExpect(jsonPath("$[1].author").value("Robert C. Martin"));
-    }
-    
-    @Test
-    void testUpdateBookSuccess() throws Exception {
-        // Arrange: Create the updated version of the book
-        EBook updatedBook = new EBook("978-0134685991", "Updated Title", "Robert C. Martin", 150);
-
-        // Tell the mock service to return the updated book
-        when(bookService.updateBook(any(String.class), any(Book.class))).thenReturn(updatedBook);
-        
-        // Act & Assert: Perform a PATCH request and verify the response
-        mockMvc.perform(patch("/api/books/{isbn}", "978-0134685991")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updatedBook)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value("Updated Title"));
-    }
-
-    @Test
-    void testUpdateBookNotFound() throws Exception {
-        // Arrange: Create a book to update that does not exist
-        EBook nonExistentBook = new EBook("978-9999999999", "No Such Book", "Unknown", 0);
-
-        // Tell the mock service to throw an exception when the book is not found
-        when(bookService.updateBook(any(String.class), any(Book.class))).thenThrow(new IllegalStateException());
-
-        // Act & Assert: Perform a PATCH request and verify a NOT_FOUND status is returned
-        mockMvc.perform(patch("/api/books/{isbn}", "978-9999999999")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(nonExistentBook)))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void testDeleteBookSuccess() throws Exception {
-        // Arrange: Tell the mock service that the deletion will be successful
-        when(bookService.deleteBookByIsbn("978-0134685991")).thenReturn(true);
-
-        // Act & Assert: Perform a DELETE request and verify the NO_CONTENT status
-        mockMvc.perform(delete("/api/books/{isbn}", "978-0134685991"))
+        // Act & Assert
+        mockMvc.perform(delete("/api/books/{isbn}", isbn))
                 .andExpect(status().isNoContent());
-
-        // Verify that the service method was called exactly once
-        verify(bookService, times(1)).deleteBookByIsbn("978-0134685991");
-    }
-
-    @Test
-    void testDeleteBookNotFound() throws Exception {
-        // Arrange: Tell the mock service that the book does not exist
-        when(bookService.deleteBookByIsbn("978-9999999999")).thenReturn(false);
-
-        // Act & Assert: Perform a DELETE request and verify the NOT_FOUND status
-        mockMvc.perform(delete("/api/books/{isbn}", "978-9999999999"))
-                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
refactor the BookController test suite by splitting the single BookControllerTest class into two distinct classes: BookControllerIntegrationTest and BookControllerUnitTest.

The original class used both @SpringBootTest and @WebMvcTest, which caused a "found multiple declarations of @BootstrapWith" build error due to conflicting test context configurations.

- BookControllerIntegrationTest now contains tests that require the full application context and use TestRestTemplate to make real HTTP requests.
- BookControllerUnitTest contains isolated tests for the controller layer, using MockMvc for faster execution.